### PR TITLE
[Update] init script to make cdp4 user a SUPERUSER; fixes #1

### DIFF
--- a/cdp4-database-bare-community-edition/init-cdp4-cluster.sh
+++ b/cdp4-database-bare-community-edition/init-cdp4-cluster.sh
@@ -1,10 +1,7 @@
 #!/bin/bash
 psql -U postgres -p 5432 --command="CREATE USER cdp4 WITH PASSWORD 'cdp4';"
+psql -U postgres -p 5432 --command="ALTER USER cdp4 WITH SUPERUSER;"
 psql -U postgres -p 5432 --command="GRANT pg_signal_backend TO cdp4;"
 psql -U postgres -p 5432 --command="CREATE DATABASE cdp4manage WITH OWNER = cdp4 ENCODING 'UTF-8';"
 psql -U postgres -p 5432 -d cdp4manage --command="CREATE EXTENSION IF NOT EXISTS hstore;"
 psql -U postgres -p 5432 -d cdp4manage --command="CREATE EXTENSION IF NOT EXISTS \"uuid-ossp\";"
-psql -U postgres -p 5432 --command="GRANT CONNECT ON DATABASE cdp4manage TO cdp4;"
-psql -U postgres -p 5432 --command="GRANT ALL ON DATABASE cdp4manage TO cdp4;"
-psql -U postgres -p 5432 --command="ALTER USER cdp4 CREATEDB;"
-psql -U postgres -p 5432 --command="ALTER ROLE cdp4 SET statement_timeout = 30000;"


### PR DESCRIPTION
The init script has been update to make the cdp4 user a SUPERUSER. Therefore the dedicated permissions settings are removed as well as the cdp4 TIMEOUT statement that is actually not required